### PR TITLE
Use CockroachDB as default database

### DIFF
--- a/cmd/gitpods/dev.go
+++ b/cmd/gitpods/dev.go
@@ -41,7 +41,7 @@ var (
 		cli.StringFlag{
 			Name:  "database-dsn",
 			Usage: "The database connection data",
-			Value: "postgres://postgres:postgres@localhost:5432?sslmode=disable",
+			Value: "postgres://root@localhost:26257/gitpods?sslmode=disable",
 		},
 		cli.StringFlag{
 			Name:  "log-level",

--- a/schema/cockroach/1494803030_create_users_table.down.sql
+++ b/schema/cockroach/1494803030_create_users_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users;

--- a/schema/cockroach/1494803030_create_users_table.up.sql
+++ b/schema/cockroach/1494803030_create_users_table.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE users (
+  id         UUID PRIMARY KEY      DEFAULT gen_random_uuid(),
+  email      VARCHAR(500) NOT NULL,
+  username   VARCHAR(32)  NOT NULL,
+  name       VARCHAR(100) NOT NULL,
+  password   TEXT         NOT NULL,
+  created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX users_email_uniq_idx
+  ON users (email);
+CREATE UNIQUE INDEX users_username_uniq_idx
+  ON users (username);

--- a/schema/cockroach/1494804546_create_repositories_table.down.sql
+++ b/schema/cockroach/1494804546_create_repositories_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE repositories;

--- a/schema/cockroach/1494804546_create_repositories_table.up.sql
+++ b/schema/cockroach/1494804546_create_repositories_table.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE repositories (
+  id             UUID PRIMARY KEY                           DEFAULT gen_random_uuid(),
+  name           TEXT NOT NULL,
+  description    TEXT,
+  website        TEXT,
+  default_branch TEXT         NOT NULL,
+  created_at     TIMESTAMPTZ  NOT NULL                      DEFAULT now(),
+  updated_at     TIMESTAMPTZ  NOT NULL                      DEFAULT now(),
+  owner_id       UUID REFERENCES users NOT NULL
+);
+
+ALTER TABLE repositories ADD UNIQUE (name, owner_id);

--- a/schema/cockroach/1495231047_create_sessions_table.down.sql
+++ b/schema/cockroach/1495231047_create_sessions_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE sessions;

--- a/schema/cockroach/1495231047_create_sessions_table.up.sql
+++ b/schema/cockroach/1495231047_create_sessions_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE sessions (
+  id       UUID PRIMARY KEY                 DEFAULT gen_random_uuid(),
+  expires  TIMESTAMPTZ           NOT NULL   DEFAULT now(),
+  owner_id UUID REFERENCES users NOT NULL
+);


### PR DESCRIPTION
As we already use the Postgres driver, we can easily switch to CockroachDB as default database.
In the last months I've made good experiences with CockroachDB on other projects, and it perfectly fits the ideas of GitPods, like running cloud independent on Kubernetes.
Therefore switching to CockroachDB as default database seems like the right way to go.