### PR TITLE
Add request ID to logging and tracing for correlation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -431,6 +431,14 @@
   revision = "282c8707aa210456a825798969cc27edda34992a"
 
 [[projects]]
+  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:ea81f81a99dcb2303dc72b64b8284684c43ef6a8a459d1a56e339df69890d24f"
   name = "github.com/stretchr/testify"
@@ -620,6 +628,7 @@
     "github.com/opentracing/opentracing-go",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/satori/go.uuid",
     "github.com/stretchr/testify/assert",
     "github.com/uber/jaeger-client-go",
     "github.com/uber/jaeger-client-go/config",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,3 +82,7 @@
 [[constraint]]
   name = "github.com/fatih/color"
   version = "1.7.0"
+
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+  version = "1.2.0"

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -233,7 +233,7 @@ func apiAction(c *cli.Context) error {
 	router := chi.NewRouter()
 	{
 		router.Use(api.NewRequestID)
-		router.Use(cmd.NewRequestLogger(logger))
+		router.Use(api.NewRequestLogger(logger))
 
 		// Wrap the router inside a Router handler to make it possible to listen on / or on /api.
 		// Change via APIPrefix.

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gitpods/gitpods/cmd"
+	"github.com/gitpods/gitpods/pkg/api"
 	apiv1 "github.com/gitpods/gitpods/pkg/api/v1"
 	"github.com/gitpods/gitpods/pkg/authorization"
 	"github.com/gitpods/gitpods/pkg/gitpods/repository"
@@ -231,6 +232,7 @@ func apiAction(c *cli.Context) error {
 	//
 	router := chi.NewRouter()
 	{
+		router.Use(api.NewRequestID)
 		router.Use(cmd.NewRequestLogger(logger))
 
 		// Wrap the router inside a Router handler to make it possible to listen on / or on /api.

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -211,13 +211,13 @@ func apiAction(c *cli.Context) error {
 
 	var us user.Service
 	us = user.NewService(users)
-	us = user.NewLoggingService(log.WithPrefix(logger, "service", "user"), us)
-	us = user.NewTracingService(us)
+	us = user.NewLoggingService(us, api.GetRequestID, log.WithPrefix(logger, "service", "user"))
+	us = user.NewTracingService(us, api.GetRequestID)
 
 	var rs repository.Service
 	rs = repository.NewService(repositories, storageClient)
-	rs = repository.NewLoggingService(log.WithPrefix(logger, "service", "repository"), rs)
-	rs = repository.NewTracingService(rs)
+	rs = repository.NewLoggingService(rs, api.GetRequestID, log.WithPrefix(logger, "service", "repository"))
+	rs = repository.NewTracingService(rs, api.GetRequestID)
 
 	//
 	// OpenAPI

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,13 +1,9 @@
 package cmd
 
 import (
-	"net/http"
 	"os"
 	"strings"
-	"time"
 
-	"github.com/gitpods/gitpods/pkg/api"
-	"github.com/go-chi/chi/middleware"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 )
@@ -70,25 +66,4 @@ func NewLogger(json bool, loglevel string) log.Logger {
 		"ts", log.DefaultTimestampUTC,
 		"caller", log.DefaultCaller,
 	)
-}
-
-func NewRequestLogger(logger log.Logger) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			start := time.Now()
-
-			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-			next.ServeHTTP(ww, r)
-
-			level.Debug(logger).Log(
-				"request", api.GetRequestID(r.Context()),
-				"proto", r.Proto,
-				"method", r.Method,
-				"status", ww.Status(),
-				"path", r.URL.Path,
-				"duration", time.Since(start),
-				"bytes", ww.BytesWritten(),
-			)
-		})
-	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitpods/gitpods/pkg/api"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -80,6 +81,7 @@ func NewRequestLogger(logger log.Logger) func(next http.Handler) http.Handler {
 			next.ServeHTTP(ww, r)
 
 			level.Debug(logger).Log(
+				"request", api.GetRequestID(r.Context()),
 				"proto", r.Proto,
 				"method", r.Method,
 				"status", ww.Status(),

--- a/cmd/storage/githttp.go
+++ b/cmd/storage/githttp.go
@@ -17,11 +17,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gitpods/gitpods/cmd"
+	"github.com/gitpods/gitpods/pkg/api"
 	"github.com/go-chi/chi"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 type GitHTTP struct {
@@ -40,7 +40,7 @@ func NewGitHTTP(root string) *GitHTTP {
 
 func (gh *GitHTTP) Handler() *chi.Mux {
 	r := chi.NewRouter()
-	r.Use(cmd.NewRequestLogger(gh.Logger))
+	r.Use(api.NewRequestLogger(gh.Logger))
 
 	r.Get("/{owner}/{name}/HEAD", noCaching(gh.headHandler))
 	r.Get("/{owner}/{name}/info/refs", noCaching(gh.infoRefsHandler))

--- a/cmd/ui/ui.go
+++ b/cmd/ui/ui.go
@@ -4,6 +4,8 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/gitpods/gitpods/pkg/api"
+
 	"github.com/gitpods/gitpods/cmd"
 	"github.com/go-chi/chi"
 	"github.com/go-kit/kit/log"
@@ -66,7 +68,8 @@ func ActionUI(c *cli.Context) error {
 	})
 
 	r := chi.NewRouter()
-	r.Use(cmd.NewRequestLogger(logger))
+	r.Use(api.NewRequestID)
+	r.Use(api.NewRequestLogger(logger))
 
 	r.Get("/", homeHandler)
 	r.NotFound(homeHandler)

--- a/pkg/api/request_id.go
+++ b/pkg/api/request_id.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/satori/go.uuid"
+)
+
+const contextReqID = "request_id"
+
+func NewRequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := r.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = uuid.NewV4().String()
+		}
+
+		r = r.WithContext(context.WithValue(r.Context(), contextReqID, reqID))
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func GetRequestID(ctx context.Context) string {
+	value := ctx.Value(contextReqID)
+	if reqID, ok := value.(string); ok {
+		return reqID
+	}
+	return ""
+}

--- a/pkg/api/request_id.go
+++ b/pkg/api/request_id.go
@@ -11,8 +11,11 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-const contextReqID = "request_id"
+type contextValue string
 
+const contextReqID contextValue = "request_id"
+
+//NewRequestID creates a middleware that passes X-Request-ID via contenxt or creates a new ID
 func NewRequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqID := r.Header.Get("X-Request-ID")
@@ -26,6 +29,7 @@ func NewRequestID(next http.Handler) http.Handler {
 	})
 }
 
+//GetRequestID returns the request ID from context.Context
 func GetRequestID(ctx context.Context) string {
 	value := ctx.Value(contextReqID)
 	if reqID, ok := value.(string); ok {
@@ -34,6 +38,7 @@ func GetRequestID(ctx context.Context) string {
 	return ""
 }
 
+//NewRequestLogger creates a middleware that logs all HTTP request information
 func NewRequestLogger(logger log.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/gitpods/repository/logging.go
+++ b/pkg/gitpods/repository/logging.go
@@ -9,14 +9,17 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
+type LoggingRequestID func(context.Context) string
+
 type loggingService struct {
-	logger  log.Logger
-	service Service
+	service   Service
+	requestID LoggingRequestID
+	logger    log.Logger
 }
 
 // NewLoggingService wraps the Service and provides logging for its methods.
-func NewLoggingService(logger log.Logger, s Service) Service {
-	return &loggingService{logger: logger, service: s}
+func NewLoggingService(s Service, requestID LoggingRequestID, logger log.Logger) Service {
+	return &loggingService{service: s, requestID: requestID, logger: logger}
 }
 
 func (s *loggingService) List(ctx context.Context, owner string) ([]*Repository, string, error) {
@@ -25,6 +28,7 @@ func (s *loggingService) List(ctx context.Context, owner string) ([]*Repository,
 	repositories, owner, err := s.service.List(ctx, owner)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "List",
 		"duration", time.Since(start),
 	)
@@ -48,6 +52,7 @@ func (s *loggingService) Find(ctx context.Context, owner string, name string) (*
 	repository, owner, err := s.service.Find(ctx, owner, name)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Find",
 		"duration", time.Since(start),
 	)
@@ -70,6 +75,7 @@ func (s *loggingService) Create(ctx context.Context, owner string, repository *R
 	repository, err := s.service.Create(ctx, owner, repository)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Create",
 		"duration", time.Since(start),
 	)
@@ -96,6 +102,7 @@ func (s *loggingService) Branches(ctx context.Context, owner string, name string
 	branches, err := s.service.Branches(ctx, owner, name)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Branches",
 		"duration", time.Since(start),
 	)
@@ -123,6 +130,7 @@ func (s *loggingService) Commit(ctx context.Context, owner string, name string, 
 	commit, err := s.service.Commit(ctx, owner, name, rev)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Commit",
 		"owner", owner,
 		"name", name,

--- a/pkg/gitpods/repository/logging.go
+++ b/pkg/gitpods/repository/logging.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
+//LoggingRequestID returns the request ID as string for logging
 type LoggingRequestID func(context.Context) string
 
 type loggingService struct {

--- a/pkg/gitpods/repository/tracing.go
+++ b/pkg/gitpods/repository/tracing.go
@@ -7,17 +7,21 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+type TracingRequestID func(context.Context) string
+
 type tracingService struct {
-	service Service
+	service   Service
+	requestID TracingRequestID
 }
 
 // NewTracingService wraps the Service and provides tracing for its methods.
-func NewTracingService(s Service) Service {
-	return &tracingService{service: s}
+func NewTracingService(s Service, requestID TracingRequestID) Service {
+	return &tracingService{service: s, requestID: requestID}
 }
 
 func (s *tracingService) List(ctx context.Context, owner string) ([]*Repository, string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "repository.Service.List")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("owner", owner)
 	defer span.Finish()
 
@@ -26,6 +30,7 @@ func (s *tracingService) List(ctx context.Context, owner string) ([]*Repository,
 
 func (s *tracingService) Find(ctx context.Context, owner string, name string) (*Repository, string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "repository.Service.Find")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("owner", owner)
 	span.SetTag("name", name)
 	defer span.Finish()
@@ -35,6 +40,7 @@ func (s *tracingService) Find(ctx context.Context, owner string, name string) (*
 
 func (s *tracingService) Create(ctx context.Context, owner string, repository *Repository) (*Repository, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "repository.Service.Create")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("owner", owner)
 	span.SetTag("name", repository.Name)
 	defer span.Finish()
@@ -44,6 +50,7 @@ func (s *tracingService) Create(ctx context.Context, owner string, repository *R
 
 func (s *tracingService) Branches(ctx context.Context, owner string, name string) ([]*Branch, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "repository.Service.Branches")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("owner", owner)
 	span.SetTag("name", name)
 	defer span.Finish()
@@ -53,6 +60,7 @@ func (s *tracingService) Branches(ctx context.Context, owner string, name string
 
 func (s *tracingService) Commit(ctx context.Context, owner string, name string, rev string) (storage.Commit, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "repository.Service.Commit")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("owner", owner)
 	span.SetTag("name", name)
 	span.SetTag("rev", rev)

--- a/pkg/gitpods/repository/tracing.go
+++ b/pkg/gitpods/repository/tracing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+//TracingRequestID returns the request ID as string for tracing
 type TracingRequestID func(context.Context) string
 
 type tracingService struct {

--- a/pkg/gitpods/user/logging.go
+++ b/pkg/gitpods/user/logging.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
+//LoggingRequestID returns the request ID as string for logging
 type LoggingRequestID func(context.Context) string
 
 type loggingService struct {

--- a/pkg/gitpods/user/logging.go
+++ b/pkg/gitpods/user/logging.go
@@ -8,22 +8,26 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
+type LoggingRequestID func(context.Context) string
+
 type loggingService struct {
-	logger log.Logger
-	Service
+	service   Service
+	requestID LoggingRequestID
+	logger    log.Logger
 }
 
 // NewLoggingService wraps the Service and provides logging for its methods.
-func NewLoggingService(logger log.Logger, s Service) Service {
-	return &loggingService{logger, s}
+func NewLoggingService(s Service, requestID LoggingRequestID, logger log.Logger) Service {
+	return &loggingService{service: s, requestID: requestID, logger: logger}
 }
 
 func (s *loggingService) FindAll(ctx context.Context) ([]*User, error) {
 	start := time.Now()
 
-	users, err := s.Service.FindAll(ctx)
+	users, err := s.service.FindAll(ctx)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "FindAll",
 		"duration", time.Since(start),
 	)
@@ -37,12 +41,17 @@ func (s *loggingService) FindAll(ctx context.Context) ([]*User, error) {
 	return users, err
 }
 
+func (s *loggingService) Find(context.Context, string) (*User, error) {
+	panic("implement me")
+}
+
 func (s *loggingService) FindByUsername(ctx context.Context, username string) (*User, error) {
 	start := time.Now()
 
-	user, err := s.Service.FindByUsername(ctx, username)
+	user, err := s.service.FindByUsername(ctx, username)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "FindByUsername",
 		"duration", time.Since(start),
 		"username", username,
@@ -57,12 +66,17 @@ func (s *loggingService) FindByUsername(ctx context.Context, username string) (*
 	return user, err
 }
 
+func (s *loggingService) FindRepositoryOwner(ctx context.Context, repositoryID string) (*User, error) {
+	panic("implement me")
+}
+
 func (s *loggingService) Create(ctx context.Context, user *User) (*User, error) {
 	start := time.Now()
 
-	user, err := s.Service.Create(ctx, user)
+	user, err := s.service.Create(ctx, user)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Create",
 		"duration", time.Since(start),
 		"username", user.Username,
@@ -80,9 +94,10 @@ func (s *loggingService) Create(ctx context.Context, user *User) (*User, error) 
 func (s *loggingService) Update(ctx context.Context, user *User) (*User, error) {
 	start := time.Now()
 
-	user, err := s.Service.Update(ctx, user)
+	user, err := s.service.Update(ctx, user)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Update",
 		"duration", time.Since(start),
 		"username", user.Username,
@@ -100,9 +115,10 @@ func (s *loggingService) Update(ctx context.Context, user *User) (*User, error) 
 func (s *loggingService) Delete(ctx context.Context, username string) error {
 	start := time.Now()
 
-	err := s.Service.Delete(ctx, username)
+	err := s.service.Delete(ctx, username)
 
 	logger := log.With(s.logger,
+		"request", s.requestID(ctx),
 		"method", "Delete",
 		"duration", time.Since(start),
 		"username", username,

--- a/pkg/gitpods/user/tracing.go
+++ b/pkg/gitpods/user/tracing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+//TracingRequestID returns the request ID as string for tracing
 type TracingRequestID func(context.Context) string
 
 type tracingService struct {

--- a/pkg/gitpods/user/tracing.go
+++ b/pkg/gitpods/user/tracing.go
@@ -6,17 +6,21 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+type TracingRequestID func(context.Context) string
+
 type tracingService struct {
-	service Service
+	service   Service
+	requestID TracingRequestID
 }
 
 // NewTracingService wraps the Service and provides tracing for its methods.
-func NewTracingService(s Service) Service {
-	return &tracingService{s}
+func NewTracingService(s Service, requestID TracingRequestID) Service {
+	return &tracingService{s, requestID}
 }
 
 func (s *tracingService) FindAll(ctx context.Context) ([]*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.FindAll")
+	span.SetTag("request", s.requestID(ctx))
 	defer span.Finish()
 
 	return s.service.FindAll(ctx)
@@ -24,6 +28,7 @@ func (s *tracingService) FindAll(ctx context.Context) ([]*User, error) {
 
 func (s *tracingService) Find(ctx context.Context, id string) (*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.Find")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("id", id)
 	defer span.Finish()
 
@@ -32,6 +37,7 @@ func (s *tracingService) Find(ctx context.Context, id string) (*User, error) {
 
 func (s *tracingService) FindByUsername(ctx context.Context, username string) (*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.FindByUsername")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("username", username)
 	defer span.Finish()
 
@@ -40,6 +46,7 @@ func (s *tracingService) FindByUsername(ctx context.Context, username string) (*
 
 func (s *tracingService) FindRepositoryOwner(ctx context.Context, repositoryID string) (*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.FindRepositoryOwner")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("repository", repositoryID)
 	defer span.Finish()
 
@@ -48,6 +55,7 @@ func (s *tracingService) FindRepositoryOwner(ctx context.Context, repositoryID s
 
 func (s *tracingService) Create(ctx context.Context, user *User) (*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.Create")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("username", user.Username)
 	defer span.Finish()
 
@@ -56,6 +64,7 @@ func (s *tracingService) Create(ctx context.Context, user *User) (*User, error) 
 
 func (s *tracingService) Update(ctx context.Context, user *User) (*User, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.Update")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("id", user.ID)
 	span.SetTag("username", user.Username)
 	defer span.Finish()
@@ -65,6 +74,7 @@ func (s *tracingService) Update(ctx context.Context, user *User) (*User, error) 
 
 func (s *tracingService) Delete(ctx context.Context, username string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "user.Service.Delete")
+	span.SetTag("request", s.requestID(ctx))
 	span.SetTag("username", username)
 	defer span.Finish()
 

--- a/vendor/github.com/satori/go.uuid/LICENSE
+++ b/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/satori/go.uuid/codec.go
+++ b/vendor/github.com/satori/go.uuid/codec.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b8109dad11d180b400c04fd430c8"
+// ABNF for supported UUID text representation follows:
+//   uuid := canonical | hashlike | braced | urn
+//   plain := canonical | hashlike
+//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//   hashlike := 12hexoct
+//   braced := '{' plain '}'
+//   urn := URN ':' UUID-NID ':' plain
+//   URN := 'urn'
+//   UUID-NID := 'uuid'
+//   12hexoct := 6hexoct 6hexoct
+//   6hexoct := 4hexoct 2hexoct
+//   4hexoct := 2hexoct 2hexoct
+//   2hexoct := hexoct hexoct
+//   hexoct := hexdig hexdig
+//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	switch len(text) {
+	case 32:
+		return u.decodeHashLike(text)
+	case 36:
+		return u.decodeCanonical(text)
+	case 38:
+		return u.decodeBraced(text)
+	case 41:
+		fallthrough
+	case 45:
+		return u.decodeURN(text)
+	default:
+		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
+func (u *UUID) decodeCanonical(t []byte) (err error) {
+	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	src := t[:]
+	dst := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			src = src[1:] // skip dash
+		}
+		_, err = hex.Decode(dst[:byteGroup/2], src[:byteGroup])
+		if err != nil {
+			return
+		}
+		src = src[byteGroup:]
+		dst = dst[byteGroup/2:]
+	}
+
+	return
+}
+
+// decodeHashLike decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeHashLike(t []byte) (err error) {
+	src := t[:]
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	}
+	return
+}
+
+// decodeBraced decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}" or in format
+// "{6ba7b8109dad11d180b400c04fd430c8}".
+func (u *UUID) decodeBraced(t []byte) (err error) {
+	l := len(t)
+
+	if t[0] != '{' || t[l-1] != '}' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	return u.decodePlain(t[1 : l-1])
+}
+
+// decodeURN decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in format
+// "urn:uuid:6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeURN(t []byte) (err error) {
+	total := len(t)
+
+	urn_uuid_prefix := t[:9]
+
+	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+	}
+
+	return u.decodePlain(t[9:total])
+}
+
+// decodePlain decodes UUID string in canonical format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodePlain(t []byte) (err error) {
+	switch len(t) {
+	case 32:
+		return u.decodeHashLike(t)
+	case 36:
+		return u.decodeCanonical(t)
+	default:
+		return fmt.Errorf("uuid: incorrrect UUID length: %s", t)
+	}
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != Size {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}

--- a/vendor/github.com/satori/go.uuid/generator.go
+++ b/vendor/github.com/satori/go.uuid/generator.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"hash"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+var (
+	global = newDefaultGenerator()
+
+	epochFunc = unixTimeFunc
+	posixUID  = uint32(os.Getuid())
+	posixGID  = uint32(os.Getgid())
+)
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	return global.NewV1()
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	return global.NewV2(domain)
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	return global.NewV3(ns, name)
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() UUID {
+	return global.NewV4()
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	return global.NewV5(ns, name)
+}
+
+// Generator provides interface for generating UUIDs.
+type Generator interface {
+	NewV1() UUID
+	NewV2(domain byte) UUID
+	NewV3(ns UUID, name string) UUID
+	NewV4() UUID
+	NewV5(ns UUID, name string) UUID
+}
+
+// Default generator implementation.
+type generator struct {
+	storageOnce  sync.Once
+	storageMutex sync.Mutex
+
+	lastTime      uint64
+	clockSequence uint16
+	hardwareAddr  [6]byte
+}
+
+func newDefaultGenerator() Generator {
+	return &generator{}
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func (g *generator) NewV1() UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V1)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func (g *generator) NewV2(domain byte) UUID {
+	u := UUID{}
+
+	timeNow, clockSeq, hardwareAddr := g.getStorage()
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[0:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[0:], posixGID)
+	}
+
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+	u[9] = domain
+
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V2)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func (g *generator) NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(V3)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func (g *generator) NewV4() UUID {
+	u := UUID{}
+	g.safeRandom(u[:])
+	u.SetVersion(V4)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func (g *generator) NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(V5)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+func (g *generator) initStorage() {
+	g.initClockSequence()
+	g.initHardwareAddr()
+}
+
+func (g *generator) initClockSequence() {
+	buf := make([]byte, 2)
+	g.safeRandom(buf)
+	g.clockSequence = binary.BigEndian.Uint16(buf)
+}
+
+func (g *generator) initHardwareAddr() {
+	interfaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range interfaces {
+			if len(iface.HardwareAddr) >= 6 {
+				copy(g.hardwareAddr[:], iface.HardwareAddr)
+				return
+			}
+		}
+	}
+
+	// Initialize hardwareAddr randomly in case
+	// of real network interfaces absence
+	g.safeRandom(g.hardwareAddr[:])
+
+	// Set multicast bit as recommended in RFC 4122
+	g.hardwareAddr[0] |= 0x01
+}
+
+func (g *generator) safeRandom(dest []byte) {
+	if _, err := rand.Read(dest); err != nil {
+		panic(err)
+	}
+}
+
+// Returns UUID v1/v2 storage state.
+// Returns epoch timestamp, clock sequence, and hardware address.
+func (g *generator) getStorage() (uint64, uint16, []byte) {
+	g.storageOnce.Do(g.initStorage)
+
+	g.storageMutex.Lock()
+	defer g.storageMutex.Unlock()
+
+	timeNow := epochFunc()
+	// Clock changed backwards since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= g.lastTime {
+		g.clockSequence++
+	}
+	g.lastTime = timeNow
+
+	return timeNow, g.clockSequence, g.hardwareAddr[:]
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+// This is default epoch calculation function.
+func unixTimeFunc() uint64 {
+	return epochStart + uint64(time.Now().UnixNano()/100)
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}

--- a/vendor/github.com/satori/go.uuid/sql.go
+++ b/vendor/github.com/satori/go.uuid/sql.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == Size {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}

--- a/vendor/github.com/satori/go.uuid/uuid.go
+++ b/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,161 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+)
+
+// Size of a UUID in bytes.
+const Size = 16
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [Size]byte
+
+// UUID versions
+const (
+	_ byte = iota
+	V1
+	V2
+	V3
+	V4
+	V5
+)
+
+// UUID layout variants.
+const (
+	VariantNCS byte = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+// Nil is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS  = Must(FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceURL  = Must(FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceOID  = Must(FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
+)
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() byte {
+	return u[6] >> 4
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() byte {
+	switch {
+	case (u[8] >> 7) == 0x00:
+		return VariantNCS
+	case (u[8] >> 6) == 0x02:
+		return VariantRFC4122
+	case (u[8] >> 5) == 0x06:
+		return VariantMicrosoft
+	case (u[8] >> 5) == 0x07:
+		fallthrough
+	default:
+		return VariantFuture
+	}
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits.
+func (u *UUID) SetVariant(v byte) {
+	switch v {
+	case VariantNCS:
+		u[8] = (u[8]&(0xff>>1) | (0x00 << 7))
+	case VariantRFC4122:
+		u[8] = (u[8]&(0xff>>2) | (0x02 << 6))
+	case VariantMicrosoft:
+		u[8] = (u[8]&(0xff>>3) | (0x06 << 5))
+	case VariantFuture:
+		fallthrough
+	default:
+		u[8] = (u[8]&(0xff>>3) | (0x07 << 5))
+	}
+}
+
+// Must is a helper that wraps a call to a function returning (UUID, error)
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"));
+func Must(u UUID, err error) UUID {
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
At the beginning of each HTTP request the API gets we look for an `X-Request-ID` header and its value. If nothing is set, we generate a random UUIDv4 and pass that to all functions and components via `ctx context.Context`. Each log line and trace span now contain this request ID.

When looking at logs we can grep for all log lines containing the same request id across multiple streams like `grep 'request=f537b22f-04af-4912-9b0f-b1cf6ed43a0d'` or we could use something like an ELK stack or Loki to filter for `request=f537b22f-04af-4912-9b0f-b1cf6ed43a0d`.
Additionally we can also copy `request=f537b22f-04af-4912-9b0f-b1cf6ed43a0d` and search for traces with these tags in Jaeger.
Now we're able to correlate logs and traces. This doesn't work for metrics as those get aggregated.

Here's an example of the log lines and then searching for the request ID in Jaeger. :tada: 
![screenshot from 2019-01-13 20-07-36](https://user-images.githubusercontent.com/872251/51091491-8a517d00-178b-11e9-9121-3583c85958e7.png)
![screenshot from 2019-01-13 20-08-03](https://user-images.githubusercontent.com/872251/51091493-90dff480-178b-11e9-9c25-21df73e96f8d.png)

Closes #26 

/cc @tboerger @bkcsoft @lafriks @cbrgm 