### PR TITLE
Use codecov for coverage reports in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,12 +24,11 @@ steps:
   commands:
   - make test
 
-# - name: codacy
-#   image: plugins/codacy:1
-#   pull: always
-#   settings:
-#     token:
-#       from_secret: codacy
+- name: codecov
+  image: plugins/codecov
+  settings:
+    token:
+      from_secret: codecov
 
 ---
 kind: pipeline


### PR DESCRIPTION
I tried Codacy again and couldn't the plugin to work.
For some reason I prefer codecov anyway :man_shrugging: 