### PR TITLE
Refactor commit parsing

### DIFF
--- a/pkg/storage/client.go
+++ b/pkg/storage/client.go
@@ -94,15 +94,19 @@ func (c *Client) Commit(ctx context.Context, owner string, name string, rev stri
 	}
 
 	return Commit{
-		Hash:           res.GetHash(),
-		Tree:           res.GetTree(),
-		Parent:         res.GetParent(),
-		Message:        res.GetMessage(),
-		Author:         res.GetAuthor(),
-		AuthorEmail:    res.GetAuthorEmail(),
-		AuthorDate:     time.Unix(res.GetAuthorDate(), 0),
-		Committer:      res.GetCommitter(),
-		CommitterEmail: res.GetCommitterEmail(),
-		CommitterDate:  time.Unix(res.GetCommitterDate(), 0),
+		Hash:    res.GetHash(),
+		Tree:    res.GetTree(),
+		Parent:  res.GetParent(),
+		Message: res.GetMessage(),
+		Author: Author{
+			Name:  res.GetAuthor(),
+			Email: res.GetAuthorEmail(),
+			Date:  time.Unix(res.GetAuthorDate(), 0),
+		},
+		Committer: Author{
+			Name:  res.GetCommitter(),
+			Email: res.GetCommitterEmail(),
+			Date:  time.Unix(res.GetCommitterDate(), 0),
+		},
 	}, nil
 }

--- a/pkg/storage/server.go
+++ b/pkg/storage/server.go
@@ -58,11 +58,11 @@ func (s *storageServer) Commit(ctx context.Context, req *CommitRequest) (*Commit
 		Tree:           c.Tree,
 		Parent:         c.Parent,
 		Message:        c.Message,
-		Author:         c.Author,
-		AuthorEmail:    c.AuthorEmail,
-		AuthorDate:     c.AuthorDate.Unix(),
-		Committer:      c.Committer,
-		CommitterEmail: c.CommitterEmail,
-		CommitterDate:  c.CommitterDate.Unix(),
+		Author:         c.Author.Name,
+		AuthorEmail:    c.Author.Email,
+		AuthorDate:     c.Author.Date.Unix(),
+		Committer:      c.Committer.Name,
+		CommitterEmail: c.Committer.Email,
+		CommitterDate:  c.Committer.Date.Unix(),
 	}, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -228,5 +228,6 @@ func parseCommitHeader(c *Commit, line string) (bool, error) {
 		return false, nil
 	}
 
+	// skip any excessive header-lines
 	return false, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	authorLine    = regexp.MustCompile(`(.*)\s\<(.*)\>\s(\d*)`)
-	committerLine = authorLine
+	authorLine = regexp.MustCompile(`(.*)\s\<(.*)\>\s(\d*)`)
 )
 
 type (
@@ -99,6 +98,7 @@ type Commit struct {
 	Tree    string
 	Parent  string
 	Message string
+	Body    string
 
 	Author      string
 	AuthorEmail string
@@ -134,50 +134,90 @@ func parseCommit(r io.Reader, hash string) (Commit, error) {
 	}
 
 	// if true then the following lines are the subject
-	subject := false
+	hasHeader := false
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if line == "" {
-			subject = true
+		if !hasHeader {
+			var err error
+			hasHeader, err = parseHeader(&c, line)
+			if err != nil {
+				return c, err
+			}
 			continue
 		}
 
-		if subject {
+		if c.Message == "" {
 			c.Message = line
+		} else {
+			// TODO: use a string.Builder instead?
+			// TODO: handle commit signatures
+			c.Body = fmt.Sprintf("%s\n%s", c.Body, line)
 		}
+		continue
 
-		if strings.HasPrefix(line, "tree ") {
-			c.Tree = strings.TrimPrefix(line, "tree ")
-		} else if strings.HasPrefix(line, "parent ") {
-			c.Parent = strings.TrimPrefix(line, "parent ")
-		} else if strings.HasPrefix(line, "author ") {
-			line := strings.TrimPrefix(line, "author ")
-			author := authorLine.FindStringSubmatch(line)
-
-			t, err := strconv.ParseInt(author[3], 10, 64)
-			if err != nil {
-				return c, err
-			}
-
-			c.Author = author[1]
-			c.AuthorEmail = author[2]
-			c.AuthorDate = time.Unix(t, 0)
-		} else if strings.HasPrefix(line, "committer ") {
-			line := strings.TrimPrefix(line, "committer ")
-			committer := committerLine.FindStringSubmatch(line)
-
-			t, err := strconv.ParseInt(committer[3], 10, 64)
-			if err != nil {
-				return c, err
-			}
-
-			c.Committer = committer[1]
-			c.CommitterEmail = committer[2]
-			c.CommitterDate = time.Unix(t, 0)
-		}
 	}
 
 	return c, nil
+}
+
+// returns true when it's passed the header
+func parseHeader(c *Commit, line string) (bool, error) {
+	const (
+		treePrefix      = "tree "
+		parentPrefix    = "parent "
+		authorPrefix    = "author "
+		committerPrefix = "committer "
+	)
+
+	if line == "" {
+		return true, nil
+	}
+	if strings.HasPrefix(line, treePrefix) {
+		c.Tree = strings.TrimPrefix(line, treePrefix)
+		return false, nil
+	}
+
+	if strings.HasPrefix(line, parentPrefix) {
+		c.Parent = strings.TrimPrefix(line, parentPrefix)
+		return false, nil
+	}
+
+	if strings.HasPrefix(line, authorPrefix) {
+		var err error
+		line := strings.TrimPrefix(line, authorPrefix)
+
+		c.Author, c.AuthorEmail, c.AuthorDate, err = splitAuthorLine(line)
+		if err != nil {
+			// This should probably just error out, and not return a partial commit...
+			return false, err
+		}
+		return false, nil
+	}
+
+	if strings.HasPrefix(line, committerPrefix) {
+		var err error
+		line := strings.TrimPrefix(line, committerPrefix)
+		c.Committer, c.CommitterEmail, c.CommitterDate, err = splitAuthorLine(line)
+		if err != nil {
+			// This should probably just error out, and not return a partial commit...
+			return false, err
+		}
+
+		return false, nil
+	}
+
+	return false, nil
+}
+
+func splitAuthorLine(line string) (string, string, time.Time, error) {
+	committer := authorLine.FindStringSubmatch(line)
+
+	t, err := strconv.ParseInt(committer[3], 10, 64)
+	if err != nil {
+		return "", "", time.Unix(0, 0), err
+	}
+
+	return committer[1], committer[2], time.Unix(t, 0), nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -167,14 +167,16 @@ func parseCommit(r io.Reader, hash string) (Commit, error) {
 
 		if c.Message == "" {
 			c.Message = line
-		} else {
-			// TODO: use a string.Builder instead?
-			// TODO: handle commit signatures
-			c.Body = fmt.Sprintf("%s\n%s", c.Body, line)
+			continue
 		}
-		continue
 
+		// TODO: use a string.Builder instead?
+		// TODO: handle commit signatures
+		c.Body = fmt.Sprintf("%s\n%s", c.Body, line)
 	}
+
+	// Trim excessive stringing new lines
+	c.Body = strings.TrimLeft(c.Body, "\n")
 
 	return c, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -141,7 +141,7 @@ func parseCommit(r io.Reader, hash string) (Commit, error) {
 
 		if !hasHeader {
 			var err error
-			hasHeader, err = parseHeader(&c, line)
+			hasHeader, err = parseCommitHeader(&c, line)
 			if err != nil {
 				return c, err
 			}
@@ -163,7 +163,7 @@ func parseCommit(r io.Reader, hash string) (Commit, error) {
 }
 
 // returns true when it's passed the header
-func parseHeader(c *Commit, line string) (bool, error) {
+func parseCommitHeader(c *Commit, line string) (bool, error) {
 	const (
 		treePrefix      = "tree "
 		parentPrefix    = "parent "

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -28,12 +28,12 @@ body`
 		Author: Author{
 			Name:  "First Lastname",
 			Email: "first.lastname@example.com",
-			Date:  time.Unix(1505935797, 0),
+			Date:  time.Unix(1505935797, 0).In(time.FixedZone("", -25200)),
 		},
 		Committer: Author{
 			Name:  "Second Lastname",
 			Email: "second.lastname@example.com",
-			Date:  time.Unix(1505935797, 0),
+			Date:  time.Unix(1505935797, 0).In(time.FixedZone("", -25200)),
 		},
 		Message: "do something very useful to conquer the world",
 		Body:    "my\nawesome\n\nbody",

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -13,7 +13,12 @@ parent ae51e9d1b987f9086cbc65e694f06759bc62e743
 author First Lastname <first.lastname@example.com> 1505935797 -0700
 committer First Lastname <first.lastname@example.com> 1505935797 -0700
 
-do something very useful to conquer the world`
+do something very useful to conquer the world
+
+my
+awesome
+
+body`
 
 	commit, err := parseCommit(bytes.NewBufferString(foo), "99cc2f794893815dfc69ab1ba3370ef3e7a9fed2")
 	assert.NoError(t, err)
@@ -24,4 +29,8 @@ do something very useful to conquer the world`
 	assert.Equal(t, "first.lastname@example.com", commit.AuthorEmail)
 	assert.Equal(t, int64(1505935797), commit.AuthorDate.Unix())
 	assert.Equal(t, "do something very useful to conquer the world", commit.Message)
+	assert.Equal(t, "First Lastname", commit.Committer)
+	assert.Equal(t, "first.lastname@example.com", commit.CommitterEmail)
+	assert.Equal(t, int64(1505935797), commit.CommitterDate.Unix())
+	assert.Equal(t, "\n\nmy\nawesome\n\nbody", commit.Body)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -13,6 +13,7 @@ func TestParseCommit(t *testing.T) {
 parent ae51e9d1b987f9086cbc65e694f06759bc62e743
 author First Lastname <first.lastname@example.com> 1505935797 -0700
 committer Second Lastname <second.lastname@example.com> 1505935797 -0700
+something Foobar
 
 do something very useful to conquer the world
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -19,18 +20,24 @@ my
 awesome
 
 body`
-
+	expected := Commit{
+		Hash:   "99cc2f794893815dfc69ab1ba3370ef3e7a9fed2",
+		Tree:   "40279100b292dd26bfda150adf1c4fd5a4e52ffe",
+		Parent: "ae51e9d1b987f9086cbc65e694f06759bc62e743",
+		Author: Author{
+			Name:  "First Lastname",
+			Email: "first.lastname@example.com",
+			Date:  time.Unix(1505935797, 0),
+		},
+		Committer: Author{
+			Name:  "Second Lastname",
+			Email: "second.lastname@example.com",
+			Date:  time.Unix(1505935797, 0),
+		},
+		Message: "do something very useful to conquer the world",
+		Body:    "my\nawesome\n\nbody",
+	}
 	commit, err := parseCommit(bytes.NewBufferString(foo), "99cc2f794893815dfc69ab1ba3370ef3e7a9fed2")
 	assert.NoError(t, err)
-	assert.Equal(t, "99cc2f794893815dfc69ab1ba3370ef3e7a9fed2", commit.Hash)
-	assert.Equal(t, "40279100b292dd26bfda150adf1c4fd5a4e52ffe", commit.Tree)
-	assert.Equal(t, "ae51e9d1b987f9086cbc65e694f06759bc62e743", commit.Parent)
-	assert.Equal(t, "First Lastname", commit.Author.Name)
-	assert.Equal(t, "first.lastname@example.com", commit.Author.Email)
-	assert.Equal(t, int64(1505935797), commit.Author.Date.Unix())
-	assert.Equal(t, "Second Lastname", commit.Committer.Name)
-	assert.Equal(t, "second.lastname@example.com", commit.Committer.Email)
-	assert.Equal(t, int64(1505935797), commit.Committer.Date.Unix())
-	assert.Equal(t, "do something very useful to conquer the world", commit.Message)
-	assert.Equal(t, "my\nawesome\n\nbody", commit.Body)
+	assert.Equal(t, expected, commit)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -11,7 +11,7 @@ func TestParseCommit(t *testing.T) {
 	foo := `tree 40279100b292dd26bfda150adf1c4fd5a4e52ffe
 parent ae51e9d1b987f9086cbc65e694f06759bc62e743
 author First Lastname <first.lastname@example.com> 1505935797 -0700
-committer First Lastname <first.lastname@example.com> 1505935797 -0700
+committer Second Lastname <second.lastname@example.com> 1505935797 -0700
 
 do something very useful to conquer the world
 
@@ -25,12 +25,12 @@ body`
 	assert.Equal(t, "99cc2f794893815dfc69ab1ba3370ef3e7a9fed2", commit.Hash)
 	assert.Equal(t, "40279100b292dd26bfda150adf1c4fd5a4e52ffe", commit.Tree)
 	assert.Equal(t, "ae51e9d1b987f9086cbc65e694f06759bc62e743", commit.Parent)
-	assert.Equal(t, "First Lastname", commit.Author)
-	assert.Equal(t, "first.lastname@example.com", commit.AuthorEmail)
-	assert.Equal(t, int64(1505935797), commit.AuthorDate.Unix())
+	assert.Equal(t, "First Lastname", commit.Author.Name)
+	assert.Equal(t, "first.lastname@example.com", commit.Author.Email)
+	assert.Equal(t, int64(1505935797), commit.Author.Date.Unix())
+	assert.Equal(t, "Second Lastname", commit.Committer.Name)
+	assert.Equal(t, "second.lastname@example.com", commit.Committer.Email)
+	assert.Equal(t, int64(1505935797), commit.Committer.Date.Unix())
 	assert.Equal(t, "do something very useful to conquer the world", commit.Message)
-	assert.Equal(t, "First Lastname", commit.Committer)
-	assert.Equal(t, "first.lastname@example.com", commit.CommitterEmail)
-	assert.Equal(t, int64(1505935797), commit.CommitterDate.Unix())
 	assert.Equal(t, "\n\nmy\nawesome\n\nbody", commit.Body)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -32,5 +32,5 @@ body`
 	assert.Equal(t, "second.lastname@example.com", commit.Committer.Email)
 	assert.Equal(t, int64(1505935797), commit.Committer.Date.Unix())
 	assert.Equal(t, "do something very useful to conquer the world", commit.Message)
-	assert.Equal(t, "\n\nmy\nawesome\n\nbody", commit.Body)
+	assert.Equal(t, "my\nawesome\n\nbody", commit.Body)
 }


### PR DESCRIPTION
- Actually parse timezones :sweat_smile: (Is useful sometimes...)
- Move author/committer into its own struct
- refactor parseCommit (this I can revert if necessary :roll_eyes: )

IMO this is slightly cleaner to read. WDYT @metalmatze 

And not sure about how we should handle signatures. Either just dump them in the body, or parse them?